### PR TITLE
Refactor core services into testable helpers

### DIFF
--- a/src/Ide.Core/Properties/InternalsVisibleTo.cs
+++ b/src/Ide.Core/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Ide.Tests")]

--- a/src/Ide.Core/Searching/CodeSearchService.cs
+++ b/src/Ide.Core/Searching/CodeSearchService.cs
@@ -32,123 +32,93 @@ public sealed class CodeSearchService : ICodeSearchService
     {
         if (string.IsNullOrWhiteSpace(root)) throw new ArgumentException("Root directory is required", nameof(root));
         if (!Directory.Exists(root)) throw new DirectoryNotFoundException(root);
-        if (string.IsNullOrEmpty(query)) return Array.Empty<SearchMatch>();
-        if (limit <= 0) return Array.Empty<SearchMatch>();
+        if (string.IsNullOrEmpty(query) || limit <= 0) return Array.Empty<SearchMatch>();
 
-        var matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
-        var includes = includeGlobs?.ToArray();
-        if (includes == null || includes.Length == 0)
-        {
-            matcher.AddInclude("**/*");
-        }
-        else
-        {
-            matcher.AddIncludePatterns(includes);
-        }
-
-        // Exclude defaults + user ones
-        var excludes = (excludeGlobs ?? Array.Empty<string>()).Concat(DefaultExclude).ToArray();
-        if (excludes.Length > 0) matcher.AddExcludePatterns(excludes);
-
-        var dirInfo = new DirectoryInfo(root);
-        var dirWrapper = new DirectoryInfoWrapper(dirInfo);
-        var result = matcher.Execute(dirWrapper);
-
+        var matcher = BuildMatcher(includeGlobs, excludeGlobs);
+        var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(root)));
         var matches = new ConcurrentBag<SearchMatch>();
-        int maxFileSizeBytes = 5 * 1024 * 1024; // 5 MB
-
-        // Prepare search function
-        Func<string, Task> processFile = async path =>
-        {
-            if (matches.Count >= limit) return;
-            if (ct.IsCancellationRequested) return;
-
-            var ext = Path.GetExtension(path);
-            if (BinaryExtensions.Contains(ext)) return;
-
-            FileInfo fi;
-            try { fi = new FileInfo(path); }
-            catch { return; }
-            if (!fi.Exists) return;
-            if (fi.Length <= 0) return; // skip empty
-            if (fi.Length > maxFileSizeBytes) return;
-
-            // Binary sniff: any NUL bytes in first 4KB
-            try
-            {
-                using var fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                var probe = new byte[Math.Min(4096, (int)Math.Min(fi.Length, int.MaxValue))];
-                int read = await fs.ReadAsync(probe, 0, probe.Length, ct).ConfigureAwait(false);
-                for (int i = 0; i < read; i++)
-                {
-                    if (probe[i] == 0) return; // binary
-                }
-            }
-            catch { return; }
-
-            // Read lines
-            string[] lines;
-            try
-            {
-                lines = await File.ReadAllLinesAsync(path, Encoding.UTF8, ct).ConfigureAwait(false);
-            }
-            catch
-            {
-                // If not UTF-8, skip
-                return;
-            }
-
-            Regex? rx = null;
-            if (kind == SearchKind.Regex)
-            {
-                try { rx = new Regex(query, RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Multiline); }
-                catch { return; }
-            }
-
-            for (int i = 0; i < lines.Length; i++)
-            {
-                if (matches.Count >= limit) break;
-                if (ct.IsCancellationRequested) break;
-
-                var line = lines[i];
-
-                if (kind == SearchKind.Literal)
-                {
-                    int start = 0;
-                    while (start <= line.Length - query.Length && matches.Count < limit)
-                    {
-                        int idx = line.IndexOf(query, start, StringComparison.OrdinalIgnoreCase);
-                        if (idx < 0) break;
-                        string preview = line.Length > 200 ? line[..200] : line;
-                        matches.Add(new SearchMatch(NormalizePath(path, root), i + 1, preview));
-                        start = idx + Math.Max(1, query.Length);
-                    }
-                }
-                else
-                {
-                    var col = rx!.Matches(line);
-                    if (col.Count > 0)
-                    {
-                        string preview = line.Length > 200 ? line[..200] : line;
-                        foreach (Match m in col)
-                        {
-                            if (matches.Count >= limit) break;
-                            matches.Add(new SearchMatch(NormalizePath(path, root), i + 1, preview));
-                        }
-                    }
-                }
-            }
-        };
-
-        // Process files (sequential to keep it simple; can be parallelized later)
         foreach (var file in result.Files)
         {
+            if (matches.Count >= limit || ct.IsCancellationRequested) break;
             var fullPath = Path.Combine(root, file.Path);
-            await processFile(fullPath).ConfigureAwait(false);
-            if (matches.Count >= limit) break;
+            if (await ShouldSkipFileAsync(fullPath, ct).ConfigureAwait(false)) continue;
+            await SearchFileAsync(fullPath, root, query, kind, limit, matches, ct).ConfigureAwait(false);
         }
-
         return matches.Take(limit).ToList();
+    }
+
+    internal static Matcher BuildMatcher(IEnumerable<string>? includeGlobs, IEnumerable<string>? excludeGlobs)
+    {
+        var m = new Matcher(StringComparison.OrdinalIgnoreCase);
+        var includes = includeGlobs?.ToArray();
+        if (includes == null || includes.Length == 0) m.AddInclude("**/*"); else m.AddIncludePatterns(includes);
+        var excludes = (excludeGlobs ?? Array.Empty<string>()).Concat(DefaultExclude).ToArray();
+        if (excludes.Length > 0) m.AddExcludePatterns(excludes);
+        return m;
+    }
+
+    internal static async Task<bool> ShouldSkipFileAsync(string path, CancellationToken ct)
+    {
+        var ext = Path.GetExtension(path);
+        if (BinaryExtensions.Contains(ext)) return true;
+        FileInfo fi; try { fi = new FileInfo(path); } catch { return true; }
+        if (!fi.Exists || fi.Length <= 0 || fi.Length > 5 * 1024 * 1024) return true;
+        var probe = new byte[Math.Min(4096, (int)Math.Min(fi.Length, int.MaxValue))];
+        try
+        {
+            using var fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            int read = await fs.ReadAsync(probe, 0, probe.Length, ct).ConfigureAwait(false);
+            for (int i = 0; i < read; i++) if (probe[i] == 0) return true;
+        }
+        catch { return true; }
+        return false;
+    }
+
+    internal static async Task SearchFileAsync(string path, string root, string query, SearchKind kind, int limit, ConcurrentBag<SearchMatch> matches, CancellationToken ct)
+    {
+        string[] lines;
+        try { lines = await File.ReadAllLinesAsync(path, Encoding.UTF8, ct).ConfigureAwait(false); }
+        catch { return; }
+        Regex? rx = kind == SearchKind.Regex ? CreateRegex(query) : null;
+        for (int i = 0; i < lines.Length && matches.Count < limit && !ct.IsCancellationRequested; i++)
+        {
+            var line = lines[i];
+            if (kind == SearchKind.Literal) MatchLiteral(line, query, path, root, i, limit, matches);
+            else if (rx != null) MatchRegex(line, rx, path, root, i, limit, matches);
+        }
+    }
+
+    internal static Regex? CreateRegex(string query)
+    {
+        try { return new Regex(query, RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Multiline); }
+        catch { return null; }
+    }
+
+    internal static void MatchLiteral(string line, string query, string path, string root, int index, int limit, ConcurrentBag<SearchMatch> matches)
+    {
+        int start = 0;
+        while (start <= line.Length - query.Length && matches.Count < limit)
+        {
+            int idx = line.IndexOf(query, start, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) break;
+            AddMatch(matches, path, root, index, line);
+            start = idx + Math.Max(1, query.Length);
+        }
+    }
+
+    internal static void MatchRegex(string line, Regex rx, string path, string root, int index, int limit, ConcurrentBag<SearchMatch> matches)
+    {
+        foreach (Match _ in rx.Matches(line))
+        {
+            if (matches.Count >= limit) break;
+            AddMatch(matches, path, root, index, line);
+        }
+    }
+
+    internal static void AddMatch(ConcurrentBag<SearchMatch> matches, string path, string root, int index, string line)
+    {
+        string preview = line.Length > 200 ? line[..200] : line;
+        matches.Add(new SearchMatch(NormalizePath(path, root), index + 1, preview));
     }
 
     private static string NormalizePath(string path, string root)

--- a/xunit/IndexerTests.cs
+++ b/xunit/IndexerTests.cs
@@ -63,4 +63,17 @@ public class IndexerTests
         // Only a.cs lines should appear; not b.txt
         Assert.All(resAlpha, r => Assert.EndsWith("a.cs", Path.GetFileName(r.File)));
     }
+
+    [Fact]
+    public async Task Helpers_Build_IsIncluded_Skip_Index()
+    {
+        var root = CreateTempTree();
+        using var idx = new LexicalIndexer();
+        var include = LexicalIndexer.BuildMatcher(new[] { "src/**/*.cs" });
+        var exclude = LexicalIndexer.BuildMatcher(new[] { "bin/**" });
+        Assert.True(LexicalIndexer.IsIncluded("src/a.cs", include, exclude));
+        Assert.False(await idx.ShouldSkipFileAsync(Path.Combine(root, "src", "a.cs"), default));
+        int count = await idx.IndexFileAsync(Path.Combine(root, "src", "a.cs"), default);
+        Assert.True(count > 0);
+    }
 }


### PR DESCRIPTION
## Summary
- break down FileService into small helpers for reading, writing and diff parsing
- refactor CodeSearchService and LexicalIndexer into composable helper methods
- add internal access for tests and cover new helpers with unit tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab2e89ee90832fa387ed6b7ffe4890