### PR TITLE
refactor: centralize binary extension set

### DIFF
--- a/src/Ide.Core/Files/FileService.cs
+++ b/src/Ide.Core/Files/FileService.cs
@@ -7,18 +7,12 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Ide.Core.Utils;
 
 namespace Ide.Core.Files;
 
 public sealed class FileService : IFileService
 {
-    private static readonly HashSet<string> BinaryExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".png",".jpg",".jpeg",".gif",".bmp",".webp",".svg",".tiff",".ico",".heic",".heif",
-        ".dll",".exe",".so",".dylib",".a",".lib",".pdf",".zip",".gz",".tar",".7z",".rar",
-        ".mp3",".mp4",".mov",".avi",".mkv",".class",".jar",".wasm"
-    };
-
     private const int DefaultMaxBytes = 1_000_000; // 1 MB per file for read
 
     public async Task<IReadOnlyList<ReadResult>> ReadFilesAsync(
@@ -129,7 +123,7 @@ public sealed class FileService : IFileService
     internal static async Task<bool> IsBinaryAsync(string path, int sniffBytes, CancellationToken ct)
     {
         var ext = Path.GetExtension(path);
-        if (!string.IsNullOrEmpty(ext) && BinaryExtensions.Contains(ext)) return true;
+        if (!string.IsNullOrEmpty(ext) && BinaryExtensions.Set.Contains(ext)) return true;
         if (sniffBytes <= 0) return false;
         var buf = ArrayPool<byte>.Shared.Rent(sniffBytes);
         try

--- a/src/Ide.Core/Indexing/LexicalIndexer.cs
+++ b/src/Ide.Core/Indexing/LexicalIndexer.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Ide.Core.Utils;
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Ide.Core.Indexing;
@@ -13,12 +14,6 @@ namespace Ide.Core.Indexing;
 public sealed class LexicalIndexer : IIndexer
 {
     private readonly List<LineEntry> _entries = new();
-    private readonly HashSet<string> _binaryExt = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".png",".jpg",".jpeg",".gif",".bmp",".webp",".svg",".tiff",".ico",".heic",".heif",
-        ".dll",".exe",".so",".dylib",".a",".lib",".pdf",".zip",".gz",".tar",".7z",".rar",
-        ".mp3",".mp4",".mov",".avi",".mkv",".class",".jar",".wasm"
-    };
 
     private const int MaxFileBytes = 2_000_000; // 2MB per file
 
@@ -62,7 +57,7 @@ public sealed class LexicalIndexer : IIndexer
     internal async Task<bool> ShouldSkipFileAsync(string file, CancellationToken ct)
     {
         var ext = Path.GetExtension(file);
-        if (!string.IsNullOrEmpty(ext) && _binaryExt.Contains(ext)) return true;
+        if (!string.IsNullOrEmpty(ext) && BinaryExtensions.Set.Contains(ext)) return true;
         FileInfo fi; try { fi = new FileInfo(file); } catch { return true; }
         if (fi.Length > MaxFileBytes) return true;
         int sniff = (int)Math.Min(8192, fi.Length);

--- a/src/Ide.Core/Searching/CodeSearchService.cs
+++ b/src/Ide.Core/Searching/CodeSearchService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
+using Ide.Core.Utils;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 
@@ -12,13 +13,6 @@ public sealed class CodeSearchService : ICodeSearchService
     {
         "**/bin/**", "**/obj/**", "**/.git/**", "**/.vs/**", "**/.idea/**", "**/.vscode/**",
         "**/TestResults/**", "**/artifacts/**", "**/node_modules/**"
-    };
-
-    private static readonly HashSet<string> BinaryExtensions = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ".dll", ".exe", ".so", ".dylib", ".a", ".zip", ".7z", ".rar", ".gz", ".tar",
-        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".ico", ".pdf", ".nupkg", ".snupkg",
-        ".apk", ".aab", ".ipa"
     };
 
     public async Task<IReadOnlyList<SearchMatch>> SearchAsync(
@@ -60,7 +54,7 @@ public sealed class CodeSearchService : ICodeSearchService
     internal static async Task<bool> ShouldSkipFileAsync(string path, CancellationToken ct)
     {
         var ext = Path.GetExtension(path);
-        if (BinaryExtensions.Contains(ext)) return true;
+        if (BinaryExtensions.Set.Contains(ext)) return true;
         FileInfo fi; try { fi = new FileInfo(path); } catch { return true; }
         if (!fi.Exists || fi.Length <= 0 || fi.Length > 5 * 1024 * 1024) return true;
         var probe = new byte[Math.Min(4096, (int)Math.Min(fi.Length, int.MaxValue))];

--- a/src/Ide.Core/Utils/BinaryExtensions.cs
+++ b/src/Ide.Core/Utils/BinaryExtensions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Ide.Core.Utils;
+
+/// <summary>
+/// Provides a central list of binary file extensions.
+/// </summary>
+public static class BinaryExtensions
+{
+    /// <summary>
+    /// Shared set of binary file extensions.
+    /// </summary>
+    public static HashSet<string> Set { get; } = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg", ".tiff", ".ico", ".heic", ".heif",
+        ".dll", ".exe", ".so", ".dylib", ".a", ".lib", ".pdf", ".zip", ".gz", ".tar", ".7z", ".rar",
+        ".mp3", ".mp4", ".mov", ".avi", ".mkv", ".class", ".jar", ".wasm",
+        ".nupkg", ".snupkg", ".apk", ".aab", ".ipa"
+    };
+}
+

--- a/xunit/BinaryExtensionsTests.cs
+++ b/xunit/BinaryExtensionsTests.cs
@@ -1,0 +1,33 @@
+using System.IO;
+using Ide.Core.Files;
+using Ide.Core.Indexing;
+using Ide.Core.Searching;
+using Ide.Core.Utils;
+
+namespace Ide.Tests;
+
+public class BinaryExtensionsTests
+{
+    [Fact]
+    public async Task CentralList_AffectsAllServices()
+    {
+        const string ext = ".foo";
+        var dir = Path.Combine(Path.GetTempPath(), "ide-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "a" + ext);
+        await File.WriteAllTextAsync(path, "hi");
+        var idx = new LexicalIndexer();
+        Assert.False(await FileService.IsBinaryAsync(path, 10, default));
+        Assert.False(await idx.ShouldSkipFileAsync(path, default));
+        Assert.False(await CodeSearchService.ShouldSkipFileAsync(path, default));
+        BinaryExtensions.Set.Add(ext);
+        try
+        {
+            Assert.True(await FileService.IsBinaryAsync(path, 10, default));
+            Assert.True(await idx.ShouldSkipFileAsync(path, default));
+            Assert.True(await CodeSearchService.ShouldSkipFileAsync(path, default));
+        }
+        finally { BinaryExtensions.Set.Remove(ext); }
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize binary extension list in `BinaryExtensions`
- use shared set in FileService, LexicalIndexer, and CodeSearchService
- verify all services honor central list

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet test xunit/xunit.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ab4c033360832fb4a277abeadbf393