### PR TITLE
feat: add immutable state store service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial OSS docs: README, LICENSE, Code of Conduct, Contributing, Governance, Security, Support, Changelog, Dev Guide, Roadmap, GitHub templates
 - Core EventBus implementation and tests
+- In-memory StateStore with snapshot/restore and DI wiring
 

--- a/ide/MauiProgram.cs
+++ b/ide/MauiProgram.cs
@@ -6,6 +6,7 @@ using Ide.Core.Files;
 using Ide.Core.Searching;
 using Ide.Core.Vcs;
 using Ide.Core.Indexing;
+using Ide.Core.State;
 
 namespace ide;
 
@@ -30,6 +31,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<IBrowseService, BrowseService>();
         builder.Services.AddSingleton<IGitService, GitService>();
         builder.Services.AddSingleton<IIndexer, LexicalIndexer>();
+        builder.Services.AddSingleton<IStateStore, StateStore>();
         builder.Services.AddSingleton<IShellDiscovery, ShellDiscovery>();
         builder.Services.AddSingleton<ITerminalBackend>(sp =>
         {

--- a/src/Ide.Core/State/IStateStore.cs
+++ b/src/Ide.Core/State/IStateStore.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Ide.Core.State;
+
+/// <summary>
+/// Provides typed access to application state.
+/// </summary>
+public interface IStateStore
+{
+    /// <summary>
+    /// Store a value under the specified key.
+    /// </summary>
+    /// <typeparam name="T">Value type.</typeparam>
+    /// <param name="key">State key.</param>
+    /// <param name="value">Value to store.</param>
+    void Set<T>(string key, T value);
+
+    /// <summary>
+    /// Try to retrieve a value by key.
+    /// </summary>
+    /// <typeparam name="T">Expected type.</typeparam>
+    /// <param name="key">State key.</param>
+    /// <param name="value">Output value if found.</param>
+    /// <returns>True if key exists and value is of type T.</returns>
+    bool TryGet<T>(string key, out T? value);
+
+    /// <summary>
+    /// Get an immutable snapshot of current state.
+    /// </summary>
+    IReadOnlyDictionary<string, object?> Snapshot();
+
+    /// <summary>
+    /// Replace the store with a snapshot.
+    /// </summary>
+    /// <param name="snapshot">Snapshot to restore.</param>
+    void Restore(IReadOnlyDictionary<string, object?> snapshot);
+}

--- a/src/Ide.Core/State/StateStore.cs
+++ b/src/Ide.Core/State/StateStore.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Ide.Core.State;
+
+/// <summary>
+/// Thread-safe in-memory state store using immutable dictionaries.
+/// </summary>
+public sealed class StateStore : IStateStore
+{
+    private ImmutableDictionary<string, object?> _state = ImmutableDictionary<string, object?>.Empty;
+
+    public void Set<T>(string key, T value)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        ImmutableInterlocked.Update(ref _state, s => s.SetItem(key, value));
+    }
+
+    public bool TryGet<T>(string key, out T? value)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        if (_state.TryGetValue(key, out var v) && v is T t)
+        {
+            value = t;
+            return true;
+        }
+        value = default;
+        return false;
+    }
+
+    public IReadOnlyDictionary<string, object?> Snapshot() => _state;
+
+    public void Restore(IReadOnlyDictionary<string, object?> snapshot)
+    {
+        if (snapshot is null) throw new ArgumentNullException(nameof(snapshot));
+        var imm = snapshot as ImmutableDictionary<string, object?>
+            ?? ImmutableDictionary.CreateRange(snapshot);
+        Interlocked.Exchange(ref _state, imm);
+    }
+}

--- a/xunit/DependencyInjectionTests.cs
+++ b/xunit/DependencyInjectionTests.cs
@@ -2,6 +2,7 @@ using Ide.Core.Events;
 using Ide.Core.Files;
 using Ide.Core.Searching;
 using Microsoft.Extensions.DependencyInjection;
+using Ide.Core.State;
 
 namespace Ide.Tests;
 
@@ -14,6 +15,7 @@ public class DependencyInjectionTests
         services.AddSingleton<IFileService, FileService>();
         services.AddSingleton<IBrowseService, BrowseService>();
         services.AddSingleton<ICodeSearchService, CodeSearchService>();
+        services.AddSingleton<IStateStore, StateStore>();
         return services.BuildServiceProvider();
     }
 
@@ -25,5 +27,6 @@ public class DependencyInjectionTests
         Assert.NotNull(sp.GetService<IFileService>());
         Assert.NotNull(sp.GetService<IBrowseService>());
         Assert.NotNull(sp.GetService<ICodeSearchService>());
+        Assert.NotNull(sp.GetService<IStateStore>());
     }
 }

--- a/xunit/StateStoreTests.cs
+++ b/xunit/StateStoreTests.cs
@@ -1,0 +1,27 @@
+using Ide.Core.State;
+
+namespace Ide.Tests;
+
+public class StateStoreTests
+{
+    [Fact]
+    public void Set_And_TryGet_Returns_Value()
+    {
+        var store = new StateStore();
+        store.Set("mode", "Ask");
+        Assert.True(store.TryGet<string>("mode", out var mode));
+        Assert.Equal("Ask", mode);
+    }
+
+    [Fact]
+    public void Snapshot_And_Restore_Works()
+    {
+        var store = new StateStore();
+        store.Set("count", 1);
+        var snap = store.Snapshot();
+        store.Set("count", 2);
+        store.Restore(snap);
+        Assert.True(store.TryGet<int>("count", out var value));
+        Assert.Equal(1, value);
+    }
+}


### PR DESCRIPTION
## Summary
- add typed state store with snapshot and restore
- wire state store into DI and add coverage tests
- document state store in changelog

## Testing
- `dotnet test xunit/xunit.csproj -c Debug` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab63fb5048832fa066a82a476185b1