### PR TITLE
feat(ui): add left strap and status bar

### DIFF
--- a/ide/MainPage.xaml
+++ b/ide/MainPage.xaml
@@ -20,9 +20,19 @@
             <MenuFlyoutItem Text="Save Project (All)" Clicked="OnSaveProjectMenuClicked" />
         </MenuBarItem>
     </ContentPage.MenuBarItems>
-    <Grid RowDefinitions="*" ColumnDefinitions="280,*,360" Padding="0">
+    <Grid RowDefinitions="*,24" ColumnDefinitions="40,280,*,360" Padding="0">
+        <!-- Left Strap Icons -->
+        <Border Grid.Row="0" Grid.Column="0" StrokeThickness="1" Stroke="LightGray" Padding="4">
+            <VerticalStackLayout Spacing="12" HorizontalOptions="Center" VerticalOptions="Start">
+                <Button Text="E" WidthRequest="28" HeightRequest="28" />
+                <Button Text="S" WidthRequest="28" HeightRequest="28" />
+                <Button Text="C" WidthRequest="28" HeightRequest="28" />
+                <Button Text="X" WidthRequest="28" HeightRequest="28" />
+            </VerticalStackLayout>
+        </Border>
+
         <!-- Explorer Panel (Left) -->
-        <Border Grid.Column="0" StrokeThickness="1" Stroke="LightGray" Padding="8">
+        <Border Grid.Row="0" Grid.Column="1" StrokeThickness="1" Stroke="LightGray" Padding="8">
             <VerticalStackLayout Spacing="8">
                 <Label Text="Explorer" FontAttributes="Bold" />
                 <CollectionView x:Name="FileList" SelectionMode="Single" SelectionChanged="OnFileSelected">
@@ -36,7 +46,7 @@
         </Border>
 
         <!-- Center Column (Editor over Terminal) -->
-        <Grid Grid.Column="1" RowDefinitions="*,220" ColumnDefinitions="*" Padding="0">
+        <Grid Grid.Row="0" Grid.Column="2" RowDefinitions="*,220" ColumnDefinitions="*" Padding="0">
             <!-- Editor (Top) -->
             <Border Grid.Row="0" StrokeThickness="1" Stroke="LightGray" Padding="8">
                 <Grid RowDefinitions="Auto,*" ColumnDefinitions="*">
@@ -60,11 +70,15 @@
         </Grid>
 
         <!-- Right Panel: AI Chat -->
-        <Border Grid.Column="2" StrokeThickness="1" Stroke="LightGray" Padding="8">
+        <Border Grid.Row="0" Grid.Column="3" StrokeThickness="1" Stroke="LightGray" Padding="8">
             <VerticalStackLayout Spacing="8">
                 <Label Text="AI Chat" FontAttributes="Bold" />
                 <Label Text="Conversational agent will appear here." FontSize="12" TextColor="Gray" />
             </VerticalStackLayout>
+        </Border>
+        <!-- Bottom Status Bar -->
+        <Border Grid.Row="1" Grid.ColumnSpan="4" StrokeThickness="1" Stroke="LightGray" Padding="4">
+            <Label x:Name="StatusLabel" Text="Ready" />
         </Border>
     </Grid>
 </ContentPage>

--- a/ide/MainPage.xaml.cs
+++ b/ide/MainPage.xaml.cs
@@ -33,9 +33,15 @@ public partial class MainPage : ContentPage
         _terminal = terminal;
         _terminal.Output += AppendTerminal;
         _terminal.Error += AppendTerminal;
+        SetStatus("Ready");
     }
 
     public static MainPage Create() => App.Current.Services.GetRequiredService<MainPage>();
+
+    private void SetStatus(string text)
+    {
+        StatusLabel.Text = text;
+    }
 
     protected override void OnAppearing()
     {


### PR DESCRIPTION
## Summary
- add left icon strap and bottom status bar to main page layout
- expose SetStatus helper to update bottom status label

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6ac02670832f900ae516f69acff7