### PR TITLE
feat: open files on double-click

### DIFF
--- a/ide/MainPage.xaml
+++ b/ide/MainPage.xaml
@@ -40,10 +40,14 @@
         <Border Grid.Row="0" Grid.Column="1" StrokeThickness="1" Stroke="LightGray" Padding="8">
             <VerticalStackLayout Spacing="8">
                 <Label Text="Explorer" FontAttributes="Bold" />
-                <TreeView x:Name="FileTree" SelectionChanged="OnFileSelected">
+                <TreeView x:Name="FileTree">
                     <TreeView.ItemTemplate>
                         <HierarchicalDataTemplate ItemsSource="{Binding Children}">
-                            <Label Text="{Binding Name}" />
+                            <Label Text="{Binding Name}">
+                                <Label.GestureRecognizers>
+                                    <TapGestureRecognizer NumberOfTapsRequired="2" Tapped="OnFileDoubleTapped" />
+                                </Label.GestureRecognizers>
+                            </Label>
                         </HierarchicalDataTemplate>
                     </TreeView.ItemTemplate>
                 </TreeView>


### PR DESCRIPTION
## Summary
- open files in the center editor when double-clicked in the explorer tree
- centralize file loading logic

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d6e7130832fadd2f3e69cc5ad31