### PR TITLE
fix: correct string interpolation in error display

### DIFF
--- a/ide/MainPage.xaml.cs
+++ b/ide/MainPage.xaml.cs
@@ -83,7 +83,7 @@ public partial class MainPage : ContentPage
             }
             else
             {
-                AppendTerminal($"[open error] {r?.Error ?? \"unknown\"}\n");
+                AppendTerminal($"[open error] {r?.Error ?? "unknown"}\n");
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- fix erroneous escaping in `MainPage.xaml.cs` so open-file errors display correctly

## Testing
- `dotnet build -t:Run -f net9.0-maccatalyst ide/ide.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac507e0314832fb3f19b6ad983439f