### PR TITLE
Resolve FileTree reference build error

### DIFF
--- a/ide/MainPage.xaml.cs
+++ b/ide/MainPage.xaml.cs
@@ -23,10 +23,12 @@ public partial class MainPage : ContentPage
     private readonly IBrowseService _browseService;
     private readonly IFileService _fileService;
 
+    private TreeView FileTreeView => this.FindByName<TreeView>("FileTree");
+
     public MainPage(IBrowseService browseService, IFileService fileService, ITerminalBackend terminal)
     {
         InitializeComponent();
-        FileTree.ItemsSource = _nodes;
+        FileTreeView.ItemsSource = _nodes;
         _browseService = browseService;
         _fileService = fileService;
         _terminal = terminal;


### PR DESCRIPTION
## Summary
- retrieve MainPage TreeView via FindByName and bind it at runtime

## Testing
- `dotnet build src/Ide.Core/Ide.Core.csproj`
- `dotnet build -t:Run -f net9.0-maccatalyst ide/ide.csproj` *(fails: project depends on MacCatalyst workload pack)*

------
https://chatgpt.com/codex/tasks/task_e_68ac55165184832f9bc24c65ced27428