### PR TITLE
Enable TreeView using CommunityToolkit

### DIFF
--- a/ide/MainPage.xaml
+++ b/ide/MainPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="ide.MainPage"
              x:FactoryMethod="Create">
     <ContentPage.MenuBarItems>
@@ -40,8 +41,8 @@
         <Border Grid.Row="0" Grid.Column="1" StrokeThickness="1" Stroke="LightGray" Padding="8">
             <VerticalStackLayout Spacing="8">
                 <Label Text="Explorer" FontAttributes="Bold" />
-                <TreeView x:Name="FileTree">
-                    <TreeView.ItemTemplate>
+                <toolkit:TreeView x:Name="FileTree">
+                    <toolkit:TreeView.ItemTemplate>
                         <HierarchicalDataTemplate ItemsSource="{Binding Children}">
                             <Label Text="{Binding Name}">
                                 <Label.GestureRecognizers>
@@ -49,8 +50,8 @@
                                 </Label.GestureRecognizers>
                             </Label>
                         </HierarchicalDataTemplate>
-                    </TreeView.ItemTemplate>
-                </TreeView>
+                    </toolkit:TreeView.ItemTemplate>
+                </toolkit:TreeView>
             </VerticalStackLayout>
         </Border>
 

--- a/ide/MainPage.xaml.cs
+++ b/ide/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Ide.Core.Files;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Maui.Storage;
+using CommunityToolkit.Maui.Views;
 
 namespace ide;
 

--- a/ide/MauiProgram.cs
+++ b/ide/MauiProgram.cs
@@ -7,6 +7,7 @@ using Ide.Core.Searching;
 using Ide.Core.Vcs;
 using Ide.Core.Indexing;
 using Ide.Core.State;
+using CommunityToolkit.Maui;
 
 namespace ide;
 
@@ -15,13 +16,14 @@ public static class MauiProgram
 	public static MauiApp CreateMauiApp()
 	{
 		var builder = MauiApp.CreateBuilder();
-		builder
-			.UseMauiApp<App>()
-			.ConfigureFonts(fonts =>
-			{
-				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-			});
+                builder
+                        .UseMauiApp<App>()
+                        .UseMauiCommunityToolkit()
+                        .ConfigureFonts(fonts =>
+                        {
+                                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+                        });
 
         // Core services
         builder.Services.AddSingleton<IEventBus, EventBus>();

--- a/ide/ide.csproj
+++ b/ide/ide.csproj
@@ -60,9 +60,10 @@
 		<ProjectReference Include="../src/Ide.Core/Ide.Core.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
+                <PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
+        </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- integrate CommunityToolkit.Maui for TreeView support
- wire up toolkit in MAUI app startup
- update XAML to use toolkit TreeView control

## Testing
- `dotnet build -t:Run -f net9.0-maccatalyst ide/ide.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75530efc832f9a88b54040583164